### PR TITLE
Implement Datadog MCP tools

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+DD_API_KEY=
+DD_APP_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+!.env
 .venv
 env/
 venv/

--- a/datadog_mcp_server/__init__.py
+++ b/datadog_mcp_server/__init__.py
@@ -1,0 +1,17 @@
+"""Datadog MCP server package."""
+
+from .mcp_server import (
+    create_event,
+    list_dashboards,
+    list_monitors,
+    register_tools,
+    search_logs,
+)
+
+__all__ = [
+    "register_tools",
+    "list_dashboards",
+    "list_monitors",
+    "create_event",
+    "search_logs",
+]

--- a/datadog_mcp_server/__main__.py
+++ b/datadog_mcp_server/__main__.py
@@ -1,25 +1,41 @@
 from enum import StrEnum
+from typing import Annotated
+
+import typer
 from mcp.server.fastmcp import FastMCP
+
+from datadog_mcp_server.mcp_server import register_tools
 
 mcp = FastMCP(
     name="datadog_mcp_server",
     description="Datadog MCP Server",
 )
+register_tools(mcp)
 
 
 class Transport(StrEnum):
     """Transport type for the MCP server."""
+
     stdio = "stdio"
     sse = "sse"
 
 
-if __name__ == "__main__":
-    transport = Transport.stdio
+def _run_server(transport: Annotated[Transport, typer.Option(help="MCP transport")]) -> None:
+    """Run the MCP server using the selected transport."""
     if transport is Transport.stdio:
         print("Running MCP server with stdio transport")
     elif transport is Transport.sse:
         print("Running MCP server with SSE transport")
     else:
         raise ValueError(f"Unsupported transport: {transport}")
-    # Run the MCP server with the specified transport
     mcp.run(transport=transport.value)
+
+
+def cli() -> None:
+    """Entry point for the ``datadog_mcp_server`` console script."""
+
+    typer.run(_run_server)
+
+
+if __name__ == "__main__":
+    cli()

--- a/datadog_mcp_server/mcp_server/__init__.py
+++ b/datadog_mcp_server/mcp_server/__init__.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+from .create_event import create_event
+from .list_dashboards import list_dashboards
+from .list_monitors import list_monitors
+from .search_logs import search_logs
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register all Datadog tools on the given MCP instance."""
+    mcp.add_tool(list_dashboards)
+    mcp.add_tool(list_monitors)
+    mcp.add_tool(create_event)
+    mcp.add_tool(search_logs)
+
+
+__all__ = [
+    "register_tools",
+    "list_dashboards",
+    "list_monitors",
+    "create_event",
+    "search_logs",
+]

--- a/datadog_mcp_server/mcp_server/_client.py
+++ b/datadog_mcp_server/mcp_server/_client.py
@@ -1,0 +1,18 @@
+from datadog_api_client import ApiClient, Configuration
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def _get_client() -> ApiClient:
+    """Create a Datadog API client using environment configuration.
+
+    The client reads ``DD_API_KEY`` and ``DD_APP_KEY`` from environment variables.
+    These variables are loaded from a ``.env`` file if present. Existing
+    environment variables take precedence over values defined in ``.env``.
+
+    Returns:
+        Configured :class:`ApiClient` instance.
+    """
+
+    return ApiClient(Configuration())

--- a/datadog_mcp_server/mcp_server/create_event.py
+++ b/datadog_mcp_server/mcp_server/create_event.py
@@ -1,0 +1,26 @@
+from anyio import to_thread
+from datadog_api_client.v1.api.events_api import EventsApi
+from datadog_api_client.v1.model.event_create_request import EventCreateRequest
+
+from ._client import _get_client
+
+
+async def create_event(title: str, text: str) -> dict:
+    """Create a Datadog event.
+
+    Args:
+        title: Title of the event.
+        text: Body of the event.
+
+    Returns:
+        The created event represented as a dictionary.
+    """
+
+    def _run() -> dict:
+        with _get_client() as api_client:
+            api = EventsApi(api_client)
+            body = EventCreateRequest(title=title, text=text)
+            resp = api.create_event(body)
+            return resp.to_dict()
+
+    return await to_thread.run_sync(_run)

--- a/datadog_mcp_server/mcp_server/list_dashboards.py
+++ b/datadog_mcp_server/mcp_server/list_dashboards.py
@@ -1,0 +1,30 @@
+from anyio import to_thread
+from datadog_api_client.v1.api.dashboards_api import DashboardsApi
+
+from ._client import _get_client
+
+
+async def list_dashboards(
+    filter_shared: bool | None = None,
+    filter_deleted: bool | None = None,
+) -> dict:
+    """List dashboards from Datadog.
+
+    Args:
+        filter_shared: Whether to include only shared dashboards.
+        filter_deleted: Whether to include deleted dashboards.
+
+    Returns:
+        The response from Datadog as a dictionary.
+    """
+
+    def _run() -> dict:
+        with _get_client() as api_client:
+            api = DashboardsApi(api_client)
+            resp = api.list_dashboards(
+                filter_shared=filter_shared,
+                filter_deleted=filter_deleted,
+            )
+            return resp.to_dict()
+
+    return await to_thread.run_sync(_run)

--- a/datadog_mcp_server/mcp_server/list_monitors.py
+++ b/datadog_mcp_server/mcp_server/list_monitors.py
@@ -1,0 +1,27 @@
+from anyio import to_thread
+from datadog_api_client.v1.api.monitors_api import MonitorsApi
+
+from ._client import _get_client
+
+
+async def list_monitors(
+    name: str | None = None,
+    tags: str | None = None,
+) -> list[dict]:
+    """Retrieve monitors configured in Datadog.
+
+    Args:
+        name: Optional name used to filter monitors.
+        tags: Optional monitor tags for filtering.
+
+    Returns:
+        A list of monitors represented as dictionaries.
+    """
+
+    def _run() -> list[dict]:
+        with _get_client() as api_client:
+            api = MonitorsApi(api_client)
+            monitors = api.list_monitors(name=name, tags=tags)
+            return [m.to_dict() for m in monitors]
+
+    return await to_thread.run_sync(_run)

--- a/datadog_mcp_server/mcp_server/search_logs.py
+++ b/datadog_mcp_server/mcp_server/search_logs.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from anyio import to_thread
+from datadog_api_client.v2.api.logs_api import LogsApi
+
+from ._client import _get_client
+
+
+async def search_logs(
+    query: str,
+    start: datetime | None = None,
+    end: datetime | None = None,
+    limit: int | None = None,
+) -> list[dict]:
+    """Search logs using the Datadog Logs API.
+
+    Args:
+        query: Log search query in Datadog syntax.
+        start: Optional start time for the query.
+        end: Optional end time for the query.
+        limit: Maximum number of logs to return per request.
+
+    Returns:
+        A list of logs represented as dictionaries.
+    """
+
+    def _run() -> list[dict]:
+        with _get_client() as api_client:
+            api = LogsApi(api_client)
+            logs = api.list_logs_get_with_pagination(
+                filter_query=query,
+                filter_from=start,
+                filter_to=end,
+                page_limit=limit,
+            )
+            return [log.to_dict() for log in logs]
+
+    return await to_thread.run_sync(_run)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,11 @@ dependencies = [
     "mcp[cli]>=1.9.4",
     "pydantic>=2.11.3",
     "uvicorn>=0.34.3",
+    "python-dotenv>=1.1.0",
 ]
 
 [project.scripts]
-enrichai = "datadog_mcp_server.__main__:cli"
+datadog_mcp_server = "datadog_mcp_server.__main__:cli"
 
 [tool.uv]
 package = true

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,138 @@
+import contextlib
+import types
+import asyncio
+
+import pytest
+
+from datadog_mcp_server.mcp_server import (
+    create_event,
+    list_dashboards,
+    list_monitors,
+    search_logs,
+)
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+
+    def to_dict(self):
+        return self._data
+
+
+import importlib
+
+
+def test_list_dashboards(monkeypatch):
+    result_data = {"ok": True}
+
+    class FakeDashboardsApi:
+        def __init__(self, client):
+            self.client = client
+            assert client == "client"
+
+        def list_dashboards(self, *, filter_shared=None, filter_deleted=None):
+            assert filter_shared is True
+            assert filter_deleted is False
+            return DummyResp(result_data)
+
+    async def fake_run_sync(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    mod = importlib.import_module("datadog_mcp_server.mcp_server.list_dashboards")
+    monkeypatch.setattr(mod, "_get_client", lambda: contextlib.nullcontext("client"))
+    monkeypatch.setattr(mod, "DashboardsApi", FakeDashboardsApi)
+    monkeypatch.setattr(mod, "to_thread", types.SimpleNamespace(run_sync=fake_run_sync))
+
+    result = asyncio.run(list_dashboards(filter_shared=True, filter_deleted=False))
+    assert result == result_data
+
+
+def test_list_monitors(monkeypatch):
+    result_list = [DummyResp({"id": 1}), DummyResp({"id": 2})]
+
+    class FakeMonitorsApi:
+        def __init__(self, client):
+            assert client == "client"
+
+        def list_monitors(self, *, name=None, tags=None):
+            assert name == "foo"
+            assert tags == "tag:bar"
+            return result_list
+
+    async def fake_run_sync(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    mod = importlib.import_module("datadog_mcp_server.mcp_server.list_monitors")
+    monkeypatch.setattr(mod, "_get_client", lambda: contextlib.nullcontext("client"))
+    monkeypatch.setattr(mod, "MonitorsApi", FakeMonitorsApi)
+    monkeypatch.setattr(mod, "to_thread", types.SimpleNamespace(run_sync=fake_run_sync))
+
+    result = asyncio.run(list_monitors(name="foo", tags="tag:bar"))
+    assert result == [{"id": 1}, {"id": 2}]
+
+
+def test_create_event(monkeypatch):
+    returned = {"ok": True}
+
+    class FakeEventsApi:
+        def __init__(self, client):
+            assert client == "client"
+
+        def create_event(self, body):
+            assert body.title == "t"
+            assert body.text == "x"
+            return DummyResp(returned)
+
+    async def fake_run_sync(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    mod = importlib.import_module("datadog_mcp_server.mcp_server.create_event")
+    monkeypatch.setattr(mod, "_get_client", lambda: contextlib.nullcontext("client"))
+    monkeypatch.setattr(mod, "EventsApi", FakeEventsApi)
+    monkeypatch.setattr(mod, "to_thread", types.SimpleNamespace(run_sync=fake_run_sync))
+
+    result = asyncio.run(create_event("t", "x"))
+    assert result == returned
+
+
+def test_search_logs(monkeypatch):
+    logs = [DummyResp({"message": "hi"})]
+
+    class FakeLogsApi:
+        def __init__(self, client):
+            assert client == "client"
+
+        def list_logs_get_with_pagination(self, *, filter_query, filter_from=None, filter_to=None, page_limit=None):
+            assert filter_query == "q"
+            assert filter_from == 1
+            assert filter_to == 2
+            assert page_limit == 3
+            return logs
+
+    async def fake_run_sync(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    mod = importlib.import_module("datadog_mcp_server.mcp_server.search_logs")
+    monkeypatch.setattr(mod, "_get_client", lambda: contextlib.nullcontext("client"))
+    monkeypatch.setattr(mod, "LogsApi", FakeLogsApi)
+    monkeypatch.setattr(mod, "to_thread", types.SimpleNamespace(run_sync=fake_run_sync))
+
+    result = asyncio.run(search_logs("q", start=1, end=2, limit=3))
+    assert result == [{"message": "hi"}]
+
+
+def test_entrypoint_name():
+    import tomllib
+    import pathlib
+    data = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
+    scripts = data.get("project", {}).get("scripts", {})
+    assert "datadog_mcp_server" in scripts
+    assert "enrichai" not in scripts
+
+
+def test_main_docstring_no_enrichai():
+    import pathlib
+
+    text = pathlib.Path("datadog_mcp_server/__main__.py").read_text()
+    assert "enrichai" not in text


### PR DESCRIPTION
## Summary
- split Datadog tool implementations into standalone modules
- expose new `search_logs` tool
- register all tools on server startup
- load Datadog credentials from `.env`
- provide `cli` entrypoint for running the server
- rename console script to `datadog_mcp_server`
- add unit tests for MCP tools

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68529d9d16b08323ba5714bb5c5c1c3a